### PR TITLE
Replace licenses to MIT closes #9

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,33 +1,22 @@
-GNU GENERAL PUBLIC LICENSE
-                      Version 3, 29 June 2007
+The MIT License (MIT)
 
-    An applet to show next meeting in Gnome
-    Copyright (C) 2021  Chmouel Boudjnah
+Copyright (c) 2021 Chmouel Boudjnah
 
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 An applet to show your next meetings in Gnome
 
-* Free software: GNU General Public License v3
-
 ### Features
 
 * Use [Gnome Online Account](https://linuxkamarada.com/en/2019/04/10/get-the-most-out-of-gnome-syncing-your-google-account/) for calendar sources.
@@ -93,10 +91,10 @@ application launcher thingy.
 
 ## Compatibility
 
-Works with Gnome!! 
+Works with Gnome!!
 
-It was tested as semi working on [polybar](https://github.com/polybar/polybar), it only shows 
-an icon but you can click on it to show your next meetings. 
+It was tested as semi working on [polybar](https://github.com/polybar/polybar), it only shows
+an icon but you can click on it to show your next meetings.
 Make sure you have `tray_position = position` in your polybar config to enable it.
 
 Probably works with other DE/WM supporting appindicator,
@@ -113,4 +111,8 @@ if it does so I can add it to the list.
 * Used for a while the OSX application gnome-next-meeting
   <https://apps.apple.com/us/app/next-meeting/id1017470484?mt=12> and missed it on
   Linux.
-* Used code from from @GabLeRoux for evolution calendar integration - <https://askubuntu.com/a/1371087>
+* Used code from [@GabLeRoux](https://github.com/gableroux) for evolution calendar integration - <https://askubuntu.com/a/1371087>
+
+## License
+
+[MIT](LICENSE.md) © [Chmouel Boudjnah](https://github.com/chmouel)

--- a/gnome_next_meeting_applet/applet.py
+++ b/gnome_next_meeting_applet/applet.py
@@ -1,17 +1,4 @@
 # -*- coding: utf-8 -*-
-# Author: Chmouel Boudjnah <chmouel@chmouel.com>
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
 # pylint: disable=no-self-use
 """Gnome next meeting calendar applet via Google Calendar"""
 import datetime

--- a/gnome_next_meeting_applet/evolution_calendars.py
+++ b/gnome_next_meeting_applet/evolution_calendars.py
@@ -1,20 +1,7 @@
 # -*- coding: utf-8 -*-
-# Author: Chmouel Boudjnah <chmouel@chmouel.com>
-#
-# Licensed under the Apache License, Version 2.0 (the "License"); you may
-# not use this file except in compliance with the License. You may obtain
-# a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-# License for the specific language governing permissions and limitations
-# under the License.
 # pylint: disable=no-self-use
 #
-# from Gab Leroux (@GabLeRoux) https://askubuntu.com/a/1371087
+# from Gabriel Le Breton (@GabLeRoux) https://askubuntu.com/a/1371087
 import pytz
 import datetime
 

--- a/packaging/rpm/gnome-next-meeting-applet.spec
+++ b/packaging/rpm/gnome-next-meeting-applet.spec
@@ -7,10 +7,10 @@ Version:        _VERSION_
 Release:        1%{?dist}
 Summary:        Gnome Next Meeting Applet
 
-License:        GPLv3
+License:        MIT
 URL:            http://github.com/chmouel/gnome-next-meeting-applet
 Source0:        https://github.com/chmouel/%{name}/archive/%{name}-%{version}.tar.gz
-   
+
 BuildArch:      noarch
 BuildRequires:  python3-devel
 BuildRequires:  python3-setuptools


### PR DESCRIPTION
I also fixed my name somewhere and linked to my github :raised_hands:. I think my IDE removed a few extra spaces here and there as well.