### PR TITLE
Add the ability to skip all day events

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Settings:
 * **max_results**: Max results to ask to google calendar api.
 * **skip_non_accepted**: Skip the calendar events that you didn't accept, you
   need to configure `my_emails` setting for that.
+* **skip_all_day**: Skip all day events.
 * **my_emails**: A list of email addresses.
 * **restrict_to_calendar**: Restrict to some calendar, by default it shows event from all calendars.
 * **title_max_char**: The maximum length of the title

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Settings:
 * **max_results**: Max results to ask to google calendar api.
 * **skip_non_accepted**: Skip the calendar events that you didn't accept, you
   need to configure `my_emails` setting for that.
+* **skip_non_confirmed**: Skip calendar events that are not confirmed.
 * **skip_all_day**: Skip all day events.
 * **my_emails**: A list of email addresses.
 * **restrict_to_calendar**: Restrict to some calendar, by default it shows event from all calendars.

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -8,6 +8,7 @@ title_match_icon:
   "^[Project to the Moon].*": "🌕️"
 max_results: 10
 skip_non_accepted: true
+skip_non_confirmed: false
 skip_all_day: false
 my_emails:
   - email@email.com

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -8,6 +8,7 @@ title_match_icon:
   "^[Project to the Moon].*": "🌕️"
 max_results: 10
 skip_non_accepted: true
+skip_all_day: false
 my_emails:
   - email@email.com
 # The time to query Gnome Online Accounts not to refresh calendars

--- a/gnma/applet.py
+++ b/gnma/applet.py
@@ -84,7 +84,7 @@ class Applet(goacal.GnomeOnlineAccountCal):
                     "I_CAL_STATUS_CONFIRMED"):
                 logging.debug("[SKIP] non confirmed event")
                 continue
-            if (self.config["skip_all_day"] and event.all_day == True):
+            if self.config["skip_all_day"] and event.all_day:
                 logging.debug("[SKIP] all day event")
                 continue
 

--- a/gnma/applet.py
+++ b/gnma/applet.py
@@ -84,6 +84,9 @@ class Applet(goacal.GnomeOnlineAccountCal):
                     "I_CAL_STATUS_CONFIRMED"):
                 logging.debug("[SKIP] non confirmed event")
                 continue
+            if (self.config["skip_all_day"] and event.all_day == True):
+                logging.debug("[SKIP] all day event")
+                continue
 
             skipit = False
             if self.config["skip_non_accepted"] and self.config["my_emails"]:

--- a/gnma/config.py
+++ b/gnma/config.py
@@ -10,6 +10,7 @@ DEFAULT_CONFIG = {
     "restrict_to_calendar": [],
     "skip_non_confirmed": True,
     "skip_non_accepted": False,
+    "skip_all_day": False,
     "my_emails": [],
     "max_results": 10,
     "title_max_char": 20,


### PR DESCRIPTION
Thanks for the free software!

I have a quite a few all day calendar events that aren't really "meetings" so I'd prefer them not to show as my next meeting.

This PR adds a new `skip_all_day` setting to allow these to be skipped. It defaults to `False` in order to maintain the existing behavior and be opt-in.

I've also added the existing `skip_non_confirmed` setting to the readme and default config, as it seemed to be missing.

Have a great day!