### PR TITLE
Handle Webex links

### DIFF
--- a/gnma/config.py
+++ b/gnma/config.py
@@ -36,6 +36,7 @@ VIDEOCALL_DESC_REGEXP = [
     r"(https://meet.office.com/[^\n]*)",
     r"(https://meet.microsoft.com/[^\n]*)",
     r"(https://teams.microsoft.com/[^>\n]*)",
+    r"(https://(\w+\.)?webex.*MTID=[^\s]+)",
 ]
 
 AUTOSTART_DESKTOP_FILE = """#!/usr/bin/env xdg-open

--- a/gnma/config.py
+++ b/gnma/config.py
@@ -36,7 +36,7 @@ VIDEOCALL_DESC_REGEXP = [
     r"(https://meet.office.com/[^\n]*)",
     r"(https://meet.microsoft.com/[^\n]*)",
     r"(https://teams.microsoft.com/[^>\n]*)",
-    r"(https://(\w+\.)?webex.*MTID=[^\s]+)",
+    r"(https://(\w+\.)webex\.[^\s]+MTID=[^\s]+)",
 ]
 
 AUTOSTART_DESKTOP_FILE = """#!/usr/bin/env xdg-open


### PR DESCRIPTION
I added a regex that matches the Webex URL format. 

I think for the future, two changes would be really cool:
1. The regex approach to match the URLs from the summary is prone to break and be outdated. URLs change, and this application might not be maintained forever. So I think it would be great if the app opens a summary window for all events, where the URL is not found. In this window, a user could manually pick/copy/click the right link. This will make the app more resilient.
2. It would be neat if a user could further customize the regex list. However this feature would need to be communicated very well to the user, possible you'd need a proper settings dialog. So I think very nice-to-have.

Would you be open to idea 1? I might open another PR for it, or we could put it as an issue for someone else to work on.

Thank you for this great applet :100: I would be very grateful if you create a new release for the Webex support.