### PR TITLE
Add description window for events without URL location

### DIFF
--- a/gnma/applet.py
+++ b/gnma/applet.py
@@ -153,13 +153,15 @@ class Applet(goacal.GnomeOnlineAccountCal):
             """
             Parses the event descriptions into Pango markup with clickable links.
             E-Mail descriptions are very unsafe, so it's trivial to break the markup conversion.
-            This is why we escape the descriptions and explicitly convert escaped URLs in angle-bracket
-            format back to a clickable markup URL. Regular URLs are not escaped, hence we use a normal regex.
+            This is why we escape the descriptions and explicitly convert escaped URLs in
+            angle-bracket format back to a clickable markup URL. Regular URLs are not
+            escaped, hence we use a normal regex.
             """
             # Matches normal inline links with white-space in front.
             normal_url_regex = r"(\s)(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}" \
                                r"\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:$§%_\+.~#?&\/=]*))"
-            # Matches links in the escaped angle-bracket format (https://www.rfc-editor.org/rfc/rfc2822#section-3.4)
+            # Matches links in the escaped angle-bracket format (e.g. Link<URL>)
+            # See https://www.rfc-editor.org/rfc/rfc2822#section-3.4
             escaped_angle_bracket_url_regex = r"(\S*)&lt;(.+?(?=&gt;))&gt;"
 
             description_markup = glib.markup_escape_text(description_string)
@@ -197,7 +199,8 @@ class Applet(goacal.GnomeOnlineAccountCal):
                 description_string = "\n".join(
                     map(lambda desc: desc.get_value(), source.event.comp.get_descriptions()))
 
-                label_string = (summary_string + "\n" + description_string) or "Event description is empty."
+                label_string = (summary_string + "\n" + description_string) \
+                               or "Event description is empty."
                 parsed_label_string = parse_description_to_markdown(label_string)
                 self.label.set_markup(parsed_label_string)
 

--- a/gnma/applet.py
+++ b/gnma/applet.py
@@ -88,15 +88,15 @@ class Applet(goacal.GnomeOnlineAccountCal):
                 logging.debug("[SKIP] elapsed: %s", event.summary)
                 continue
             if (
-                    self.config["starts_today_only"]
-                    and datetime.datetime.now().date() < event.end_dttime.date()
+                self.config["starts_today_only"]
+                and datetime.datetime.now().date() < event.end_dttime.date()
             ):
                 del self.all_events[event.uid]
                 logging.debug("[SKIP] non today event: %s", event.summary)
                 continue
             if (
-                    self.config["skip_non_confirmed"]
-                    and event.comp.get_status().value_name != "I_CAL_STATUS_CONFIRMED"
+                self.config["skip_non_confirmed"]
+                and event.comp.get_status().value_name != "I_CAL_STATUS_CONFIRMED"
             ):
                 logging.debug("[SKIP] non confirmed event")
                 continue
@@ -110,9 +110,9 @@ class Applet(goacal.GnomeOnlineAccountCal):
                 for attendee in event.comp.get_attendees():
                     for myemail in self.config["my_emails"]:
                         if (
-                                attendee.get_value().replace("mailto:", "") == myemail
-                                and attendee.get_partstat().value_name
-                                == "I_CAL_PARTSTAT_ACCEPTED"
+                            attendee.get_value().replace("mailto:", "") == myemail
+                            and attendee.get_partstat().value_name
+                            == "I_CAL_PARTSTAT_ACCEPTED"
                         ):
                             skipit = False
             if skipit:
@@ -148,7 +148,6 @@ class Applet(goacal.GnomeOnlineAccountCal):
         return [humanized_str, summary]
 
     def open_description_window(self, source):
-
         def parse_description_to_markdown(description_string):
             """
             Parses the event descriptions into Pango markup with clickable links.
@@ -158,8 +157,10 @@ class Applet(goacal.GnomeOnlineAccountCal):
             escaped, hence we use a normal regex.
             """
             # Matches normal inline links with white-space in front.
-            normal_url_regex = r"(\s)(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}" \
-                               r"\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:$§%_\+.~#?&\/=]*))"
+            normal_url_regex = (
+                r"(\s)(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}"
+                r"\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:$§%_\+.~#?&\/=]*))"
+            )
             # Matches links in the escaped angle-bracket format (e.g. Link<URL>)
             # See https://www.rfc-editor.org/rfc/rfc2822#section-3.4
             escaped_angle_bracket_url_regex = r"(\S*)&lt;(.+?(?=&gt;))&gt;"
@@ -168,12 +169,13 @@ class Applet(goacal.GnomeOnlineAccountCal):
             description_markup = re.sub(
                 escaped_angle_bracket_url_regex,
                 r'<a href="\2" title="\2">\1</a>',
-                description_markup
+                description_markup,
             )
             description_markup = re.sub(
                 normal_url_regex,
                 r'\1<a href="\2" title="\2">\2</a>',
-                description_markup)
+                description_markup,
+            )
 
             return description_markup
 
@@ -197,10 +199,15 @@ class Applet(goacal.GnomeOnlineAccountCal):
                 # Set all event descriptions in label
                 summary_string = source.event.comp.get_summary().get_value()
                 description_string = "\n".join(
-                    map(lambda desc: desc.get_value(), source.event.comp.get_descriptions()))
+                    map(
+                        lambda desc: desc.get_value(),
+                        source.event.comp.get_descriptions(),
+                    )
+                )
 
-                label_string = (summary_string + "\n" + description_string) \
-                               or "Event description is empty."
+                label_string = (
+                    summary_string + "\n" + description_string
+                ) or "Event description is empty."
                 parsed_label_string = parse_description_to_markdown(label_string)
                 self.label.set_markup(parsed_label_string)
 
@@ -267,9 +274,9 @@ class Applet(goacal.GnomeOnlineAccountCal):
     def make_attachment_item(self, menu, event):
         now = datetime.datetime.now()
         if not (
-                event.start_dttime < now
-                and now < event.end_dttime
-                and event.comp.get_attachments()
+            event.start_dttime < now
+            and now < event.end_dttime
+            and event.comp.get_attachments()
         ):
             return menu
         menuitem = gtk.MenuItem(label="📑 Open current meeting document")
@@ -286,7 +293,7 @@ class Applet(goacal.GnomeOnlineAccountCal):
                 return ""
 
         if event.comp.get_location() and event.comp.get_location().startswith(
-                "https://"
+            "https://"
         ):
             return event.comp.get_location()
 

--- a/gnma/applet.py
+++ b/gnma/applet.py
@@ -157,8 +157,9 @@ class Applet(goacal.GnomeOnlineAccountCal):
             format back to a clickable markup URL. Regular URLs are not escaped, hence we use a normal regex.
             """
             # Matches normal inline links with white-space in front.
-            normal_url_regex = r"(\s)(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:$§%_\+.~#?&\/=]*))"
-            # Matches inline links in the escaped angle-bracket format (https://www.rfc-editor.org/rfc/rfc2822#section-3.4)
+            normal_url_regex = r"(\s)(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}" \
+                               r"\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:$§%_\+.~#?&\/=]*))"
+            # Matches links in the escaped angle-bracket format (https://www.rfc-editor.org/rfc/rfc2822#section-3.4)
             escaped_angle_bracket_url_regex = r"(\S*)&lt;(.+?(?=&gt;))&gt;"
 
             description_markup = glib.markup_escape_text(description_string)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -31,6 +31,7 @@ def test_humanize_until_to_minute():
     assert got == expected
 
 
+@pytest.mark.skip(reason="this is buggy depend of the night 🙃")
 def test_humanize_until_to_hours_minutes():
     now = datetime.datetime.now()
     start_time = now + (datetime.timedelta(hours=1) + datetime.timedelta(minutes=11))


### PR DESCRIPTION
As discussed in #62, this PR adds a scrollable description window for events where no location URL is found. To guarantee save parsing, we escape the description before adding the clickable links. See code comment. I also decided to put both summary and description of the event into the window. 

Since you might have your own code structure preferences, I decided to move it all to one function to not clutter the namespace. You can simply refactor this, e.g. `parse_description_to_markdown` could be moved out of `open_description_window`. The definition of `EventDescriptionWindow` could also be moved. I was also unsure about the positioning and size of the window. Since its scrollable, its not so bad.

I initially toyed with the idea of implementing it via `Gtk.Popover` instead of a separate window, since the visual relation to the menu would be nice. But Popovers should only be used for small amounts of information according to the Gtk documentation. Since this is my first time working with Gtk I am totally open to any other implementation. You just need to keep the label around for the Pango markup to keep the clickable links.

So overall, it should be easy to make adaptions to this PR from your side to fit the project needs. Looking forward to your feedback, if any. I also fixed the typo in the spelling of `make_attacchment_item`.

And merry christmas! :christmas_tree: 