### PR TITLE
Fix webex URLs for angle bracket URLs

### DIFF
--- a/gnma/config.py
+++ b/gnma/config.py
@@ -36,7 +36,7 @@ VIDEOCALL_DESC_REGEXP = [
     r"(https://meet.office.com/[^\n]*)",
     r"(https://meet.microsoft.com/[^\n]*)",
     r"(https://teams.microsoft.com/[^>\n]*)",
-    r"(https://(\w+\.)webex\.[^\s]+MTID=[^\s]+)",
+    r"(https://(\w+\.)webex\.[^\s]+MTID=[^>\s]*)",
 ]
 
 AUTOSTART_DESKTOP_FILE = """#!/usr/bin/env xdg-open


### PR DESCRIPTION
This change fixes webex URLs that are embedded via the text<URL> syntax. I should have noticed that all regexs end with [^>\n]*) when I added it.

I wonder if this is actually another bug and all \n should become \s? Because it seems a safe assumption that all URLs won't have any space. Currently for example, the regex `(https://meet.microsoft.com/[^\n]*)` will match the description `The link is https://meet.microsoft.com/ID see you there!` and the result is `https://meet.microsoft.com/ID see you there!`, so also the text is included. See [demo](https://regexr.com/76gat). I think `\n` in all regexes should become a `\s`, so maybe we could add commits to this PR.